### PR TITLE
Fix scaling issue for mac (for now)

### DIFF
--- a/examples/test/main.lua
+++ b/examples/test/main.lua
@@ -30,6 +30,12 @@ function myl.main()
     myl.addComponent(entity, myl.c.Color).value = myl.color.new("#75e5eb")
     myl.addComponent(entity, myl.c.RectangleRender).size = myl.vec2(120, 120)
 
+    entity = myl.newEntity()
+    myl.addComponent(entity, myl.c.Name).value:set("BG")
+    myl.addComponent(entity, myl.c.Transform).position = myl.vec2(0, 0)
+    myl.addComponent(entity, myl.c.Color).value = myl.color.new("#f2eeae44")
+    myl.addComponent(entity, myl.c.RectangleRender).size = myl.vec2(resX, resY)
+
     window.init("myl", resX, resY, false)
     window.setVSync(true)
     local debug = false

--- a/src/modules/window.cpp
+++ b/src/modules/window.cpp
@@ -27,10 +27,28 @@ namespace modules {
 
         void init(const std::string& name, size_t width, size_t height, bool fullscreen)
         {
+            const auto dpr = getDevicePixelRatio();
+
+            if (fullscreen) {
+                const auto mode = sf::VideoMode::getDesktopMode();
+                width = mode.width;
+                height = mode.height;
+            } else {
+                width = width * dpr;
+                height = height * dpr;
+            }
+
             getWindowPtr() = std::make_unique<sf::RenderWindow>(sf::VideoMode(width, height), name,
                 fullscreen ? sf::Style::Fullscreen : sf::Style::Default);
-            ImGui::SFML::Init(getWindow());
+            auto& window = getWindow();
+            window.setView(sf::View(sf::FloatRect(0, 0, width / dpr, height / dpr)));
+            ImGui::SFML::Init(window);
+
             setImguiStyle();
+
+            ImGui::GetStyle().ScaleAllSizes(dpr);
+            ImGui::GetIO().FontGlobalScale = dpr;
+
             ImGui::SFML::UpdateFontTexture();
         }
 
@@ -64,7 +82,9 @@ namespace modules {
                 } else if (event.type == sf::Event::KeyReleased) {
                     input::internal::setState(static_cast<input::Key>(event.key.code), false);
                 } else if (event.type == sf::Event::Resized) {
-                    sf::FloatRect visibleArea(0, 0, event.size.width, event.size.height);
+                    const auto dpr = getDevicePixelRatio();
+                    sf::FloatRect visibleArea(
+                        0, 0, event.size.width / dpr, event.size.height / dpr);
                     window.setView(sf::View(visibleArea));
                 }
             }
@@ -83,6 +103,22 @@ namespace modules {
             ImGui::SFML::Render(getWindow());
             getWindow().display();
         }
+
+        /**
+         * How many device pixels per logical pixel?
+         */
+        float getDevicePixelRatio()
+        {
+#if __APPLE__
+            const auto mode = sf::VideoMode::getDesktopMode();
+            if (mode.width > 1920) {
+                // Apple and more then full HD? Must be retina aka hight DPI
+                return 2.f;
+            }
+#endif
+            return 1.f;
+        }
+
     }
 }
 }

--- a/src/modules/window.hpp
+++ b/src/modules/window.hpp
@@ -16,6 +16,7 @@ namespace modules {
         bool update();
         void clear();
         void present();
+        float getDevicePixelRatio();
     }
 }
 }


### PR DESCRIPTION
At least on my machine, it works now. The sfml stuff renders larger using the view, imgui renders larger using font scale and styles, and the devicePixelRation is determined using a heuristic.

Look at it... so beautiful.. you can read text with the naked eye: 
<img width="1440" alt="Bildschirmfoto 2020-06-01 um 03 25 59" src="https://user-images.githubusercontent.com/10676525/83368141-103d8a80-a3b8-11ea-9611-eb538d9a2f7c.png">
